### PR TITLE
Changing jobtitle to textarea

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
             <textarea id="jobtitle" name="jobtitle" rows="2" cols="50"></textarea>
             <label for="pronouns">Pronouns:</label>
             <input type="text" id="pronouns" name="pronouns">
-        </div>
+        </div> 
         <div class="preview-section">
             <div class="badge-preview">
                 <canvas id="badgeCanvas" width="296" height="128"></canvas>

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
             <label for="company">Company:</label>
             <input type="text" id="company" name="company">
             <label for="jobtitle">Job Title:</label>
-            <input type="text" id="jobtitle" name="jobtitle">
+            <textarea id="jobtitle" name="jobtitle" rows="2" cols="50"></textarea>
             <label for="pronouns">Pronouns:</label>
             <input type="text" id="pronouns" name="pronouns">
         </div>


### PR DESCRIPTION
Change jobtitle to textarea instead of text to allow for longer text with a friendly UX.
