### PR TITLE
fix broken repo link in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -58,7 +58,7 @@
                     Note that this requires the Web Serial API's which work in Chrome and Edge on the desktop, but not currently Safari
                 </p>
                 <p>
-                    To learn more about your GitHub Badger 2350, <a href=""https://github.com/badger/home">visit the repo</a>.
+                    To learn more about your GitHub Badger 2350, <a href="https://github.com/badger/home">visit the repo</a>.
                     You can also edit the code running on your Badger directly using the <a href="https://viper-ide.org/">Viper Web IDE</a> or 
                     you can install <a href="https://thonny.org/">Thonny</a> locally.
                 </p>


### PR DESCRIPTION
* [`public/index.html`](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL61-R61): Corrected the URL in the `href` attribute of the link to the GitHub Badger 2350 repository.replace double quote with single quote to fix broken link