### PR TITLE
Fixing "visit the repo" link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -58,7 +58,7 @@
                     Note that this requires the Web Serial API's which work in Chrome and Edge on the desktop, but not currently Safari
                 </p>
                 <p>
-                    To learn more about your GitHub Badger 2350, <a href=""https://github.com/badger/home">visit the repo</a>.
+                    To learn more about your GitHub Badger 2350, <a href="https://github.com/badger/home">visit the repo</a>.
                     You can also edit the code running on your Badger directly using the <a href="https://viper-ide.org/">Viper Web IDE</a> or 
                     you can install <a href="https://thonny.org/">Thonny</a> locally.
                 </p>


### PR DESCRIPTION
Fixing "visit the repo" link by removing extra "